### PR TITLE
img(terraform): update features (aws2 2026.5.21 ➡️ 2026.6.19)

### DIFF
--- a/images/src/terraform/.devcontainer/devcontainer-lock.json
+++ b/images/src/terraform/.devcontainer/devcontainer-lock.json
@@ -1,9 +1,9 @@
 {
   "features": {
     "ghcr.io/lifadev/devcontainers/features/aws2": {
-      "version": "2026.5.21",
-      "resolved": "ghcr.io/lifadev/devcontainers/features/aws2@sha256:6eac334283825824428578ff5c947a56c51398e1d84ccc997887c194bdf3eac8",
-      "integrity": "sha256:6eac334283825824428578ff5c947a56c51398e1d84ccc997887c194bdf3eac8"
+      "version": "2026.6.19",
+      "resolved": "ghcr.io/lifadev/devcontainers/features/aws2@sha256:42c5568b14067af6430adce4844ba214a24e5613e5cc0d8fdfa5b3c5d3547f88",
+      "integrity": "sha256:42c5568b14067af6430adce4844ba214a24e5613e5cc0d8fdfa5b3c5d3547f88"
     },
     "ghcr.io/lifadev/devcontainers/features/base": {
       "version": "2025.4.12",

--- a/images/src/terraform/.devcontainer/devcontainer.json
+++ b/images/src/terraform/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "debian:trixie-20260518",
+  "image": "debian:trixie-20260610",
   "features": {
     "ghcr.io/lifadev/devcontainers/features/base": {},
     "ghcr.io/lifadev/devcontainers/features/bash": {},
@@ -17,7 +17,7 @@
   "customizations": {
     "manifest": {
       "name": "terraform",
-      "version": "2026.5.22"
+      "version": "2026.6.21"
     },
     "vscode": {
       "settings": {


### PR DESCRIPTION
<!-- updater-dedupe:kind=img;name=terraform;deps=aws2=2026.6.19|base=2025.4.12|bash=2026.4.17|developer=2026.1.22|git=2026.4.20|starship=2026.4.30|terraform=2026.5.20 -->

**Features:**

- aws2: 2026.5.21 ➡️ 2026.6.19

closes #966
closes #958
closes #954
closes #950
closes #941
closes #932
closes #927
closes #925
closes #920
closes #916
closes #913
closes #909
closes #906
closes #905
closes #888
