### PR TITLE
img(terraform): update features (aws2 2026.5.21 ➡️ 2026.6.22)

### DIFF
--- a/images/src/terraform/.devcontainer/devcontainer-lock.json
+++ b/images/src/terraform/.devcontainer/devcontainer-lock.json
@@ -1,9 +1,9 @@
 {
   "features": {
     "ghcr.io/lifadev/devcontainers/features/aws2": {
-      "version": "2026.5.21",
-      "resolved": "ghcr.io/lifadev/devcontainers/features/aws2@sha256:6eac334283825824428578ff5c947a56c51398e1d84ccc997887c194bdf3eac8",
-      "integrity": "sha256:6eac334283825824428578ff5c947a56c51398e1d84ccc997887c194bdf3eac8"
+      "version": "2026.6.22",
+      "resolved": "ghcr.io/lifadev/devcontainers/features/aws2@sha256:6668481930fa53d8334352d23dfc2cf82ea5415c4d25cdc8f05855a2a97d7876",
+      "integrity": "sha256:6668481930fa53d8334352d23dfc2cf82ea5415c4d25cdc8f05855a2a97d7876"
     },
     "ghcr.io/lifadev/devcontainers/features/base": {
       "version": "2025.4.12",

--- a/images/src/terraform/.devcontainer/devcontainer.json
+++ b/images/src/terraform/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "debian:trixie-20260518",
+  "image": "debian:trixie-20260610",
   "features": {
     "ghcr.io/lifadev/devcontainers/features/base": {},
     "ghcr.io/lifadev/devcontainers/features/bash": {},
@@ -17,7 +17,7 @@
   "customizations": {
     "manifest": {
       "name": "terraform",
-      "version": "2026.5.22"
+      "version": "2026.6.23"
     },
     "vscode": {
       "settings": {


### PR DESCRIPTION
<!-- updater-dedupe:kind=img;name=terraform;deps=aws2=2026.6.22|base=2025.4.12|bash=2026.4.17|developer=2026.1.22|git=2026.4.20|starship=2026.4.30|terraform=2026.5.20 -->

**Features:**

- aws2: 2026.5.21 ➡️ 2026.6.22

closes #970
closes #966
closes #958
closes #954
closes #950
closes #941
closes #932
closes #927
closes #925
closes #920
closes #916
closes #913
closes #909
closes #906
closes #905
closes #888
